### PR TITLE
Fix PHP error logging example

### DIFF
--- a/app/Models/Usuario/PrivacidadUsuarioModel.php
+++ b/app/Models/Usuario/PrivacidadUsuarioModel.php
@@ -1,0 +1,18 @@
+<?php
+namespace Neszion\Models\Usuario;
+
+class PrivacidadUsuarioModel
+{
+    public function getVisibilidadPerfil(string $userId)
+    {
+        try {
+            // Existing logic goes here
+        } catch (\Exception $e) {
+            // Log the error message to two different log files
+            $message = "\n" . $e->getMessage();
+            error_log($message, 3, __DIR__ . '/../../logs/db_errors.log');
+            error_log($message, 3, __DIR__ . '/../../logs/app_errors.log');
+            throw $e; // rethrow or handle as needed
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PrivacidadUsuarioModel` example with corrected `error_log` usage
- keep a logs directory for output

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bf8558ee883219dc20ab2fdfd77e2